### PR TITLE
Move pixel-render details into ArduboyRenderer

### DIFF
--- a/src/arduboy/render.cpp
+++ b/src/arduboy/render.cpp
@@ -4,46 +4,127 @@ ArduboyRender::ArduboyRender(Arduboy2 &boy) : mBoy(boy) {
     beepPin.begin();
 }
 
+// Progress the beep timer on ticks.
 void ArduboyRender::tick() {
     beepPin.timer();
 }
 
-bool ArduboyRender::getPixel(uint8_t x, uint8_t y) {
-    return mBoy.getPixel(x, y) == WHITE;
+void ArduboyRender::setMode(RenderMode mode) {
+    mMode = mode; 
+    switch(mMode) {
+        case CHIP8:
+            mPixelWidth = 2;
+            mPixelHeight = 2;
+            break;
+        case CHIP8HI:
+            mPixelWidth = 2;
+            mPixelHeight = 1;
+            break;
+        case SCHIP8:
+            mPixelWidth = 1;
+            mPixelHeight = 1;
+            break;
+    }
 }
 
-void ArduboyRender::drawPixel(uint8_t x, uint8_t y, bool on) {
-    mBoy.drawPixel(x, y, on ? WHITE : BLACK);
+// Draw the pixel specified by Chip8 coordinates cx, cy with chip8 draw value
+// drawVal.
+bool ArduboyRender::drawPixel(uint8_t cx, uint8_t cy, bool drawVal) {
+    // Get the top left coordinates of the pixel rectangle we need to draw.
+    uint8_t x = (mPixelWidth * cx) % 128;
+    uint8_t y = (mPixelHeight * cy) % 64;
+
+    // Get the current pixel value, so we can xor it.
+    bool wasOn = mBoy.getPixel(x, y) == WHITE;
+
+    // Calculate the new pixel value.
+    uint8_t on = wasOn ^ drawVal;
+
+    // Draw the pixel rectangle.
+    mBoy.drawRect(x, y, mPixelWidth, mPixelHeight, on ? WHITE : BLACK); 
+
+    // A pixel draw triggers a collision when it moves from set to unset.
+    return wasOn & !on;
 }
 
-inline void ArduboyRender::scrollDown(uint8_t amt) {
-    uint8_t skip = amt/8;
+// Screen buffer is laid out in 8 pages,
+// page 0 is rows 0-7, all columns, imagine a sequence of vertical bytes
+// similar for page 1-7; 
+// So for example (using just 4 bits instead of 8), for the first page, if you
+// screen has pixel values:
+//
+// ABCDEFGH
+// IJKLMNOP
+// QRSTUVWX
+// YZ123456
+//
+// The memory layout is:
+// [AIQY, BJRZ, CKS1, DLT2, EMU3, FNV4, GOW5, HPX6]
+//
+// WIDTH is an Ardubboy2-provided constant.
+
+    
+// Implement the scrollDown function. The underlying hardware doesn't support
+// it, so we need to actually copy the memory column by column.
+inline void ArduboyRender::scrollDown(uint8_t shift) {
+    
+    // We work from the bottom up, shifting the bits of the page, and then
+    // pulling in the bits that are about to be shifted from the page above it.
+    
+    // The number of pages to skip when moving the pixels down.
+    uint8_t skip = shift / 8;
+
+    // The number of bits to shift an individual column.
+    shift = shift % 8;
+
+    // Working from the bottom up
     for(int page = 7; page >= 0; page--) {
        for(int col = 0; col < WIDTH; col++) {
-           mBoy.sBuffer[page*WIDTH+col] <<= amt;
-           uint8_t above = (page > skip) ? mBoy.sBuffer[(page-1-skip)*WIDTH+col] >> (8-amt) : 0;
+           // First, shift the bits of the page we're working with down
+           mBoy.sBuffer[page*WIDTH+col] <<= shift;
+           // Now , get the bits that are about to be shifted out from the page above.
+           uint8_t above = (page > skip) ? mBoy.sBuffer[(page-1-skip)*WIDTH+col] >> (8-shift) : 0;
+           // Or those bits with this page.
            mBoy.sBuffer[page*WIDTH+col] |= above;
        } 
     }
 }
 
+// Implement the chip8 scrollLeft function. This is easier than up/down, since
+// we just have to move the columns. The shift is always by 4.
 inline void ArduboyRender::scrollLeft() {
-    // Screen buffer is laid out in 8 pages,
-    // page 0 is rows 0-7, all columns, imagine a sequence of vertical bytes
-    // similar for page 1-7; 
+    // See above for mem layout notes.
     for(int page = 0; page < 8; page++) {
+        // Move the columns that are staying on screen to the left.
         for(int col=0; col < WIDTH-4; col++) {
+            // This column now equals the one 4 to the right.
             mBoy.sBuffer[page*WIDTH + col] = mBoy.sBuffer[page*WIDTH + col + 4];
         }
+        // Clear the 4 columns that are opened up by the scroll.
         for(int col=WIDTH-4; col < WIDTH; col++) {
             mBoy.sBuffer[page*WIDTH + col] = 0;
         }
     }
 }
 
+// Implement the chip8 scrolRight function. This is easier than up/down, since
+// we just have to move the columns. The shift is always by 4.
 inline void ArduboyRender::scrollRight() {
+    // See above for mem layout notes.
+    for(int page = 0; page < 8; page++) {
+        // Move the columns that are staynig on screen to the right.
+        for(int col=4; col < WIDTH; col++) {
+            // This column now equals the one 4 to the left.
+            mBoy.sBuffer[page*WIDTH + col] = mBoy.sBuffer[page*WIDTH + col - 4];
+        }
+        // Clear the 4 columns that are opened up by the scroll.
+        for(int col=0; col < 4; col++) {
+            mBoy.sBuffer[page*WIDTH + col] = 0;
+        }
+    }
 }
 
+// Translate the Chip8 beep duration into an Arduboy beep.
 void ArduboyRender::beep(uint8_t dur) {
     if(dur == 0) {
         beepPin.noTone();
@@ -52,18 +133,23 @@ void ArduboyRender::beep(uint8_t dur) {
     }
 }
 
+// Redraw the display.
 void ArduboyRender::render() {
     mBoy.display();
 }
 
+// Clear all pixels on the display.
 void ArduboyRender::clear() {
     mBoy.clear();
 }
 
+// Display a message when the emulator exits.
 void ArduboyRender::exit() {
     mBoy.setCursor(0,0);
     mBoy.print(F("Press key to restart"));
 }
+
+// Random implementation.
 uint8_t ArduboyRender::random() {
     return ::random(0xFF);
 }

--- a/src/arduboy/render.hpp
+++ b/src/arduboy/render.hpp
@@ -12,11 +12,14 @@ private:
     
     void message(uint16_t addr, uint16_t inst);
 
+    uint8_t mPixelWidth = 2; 
+    uint8_t mPixelHeight = 2;
+
 public:
     ArduboyRender(Arduboy2 &boy);
     void tick();
-    virtual bool getPixel(uint8_t x, uint8_t y); 
-    virtual void drawPixel(uint8_t x, uint8_t y, bool on);
+    virtual void setMode(RenderMode mode);
+    virtual bool drawPixel(uint8_t x, uint8_t y, bool drawVal);
     virtual void scrollDown(uint8_t amt);
     virtual void scrollLeft();
     virtual void scrollRight();

--- a/src/chip8/chip8.hpp
+++ b/src/chip8/chip8.hpp
@@ -40,12 +40,6 @@ class Chip8 {
     // Stack for calls.
     uint16_t mStack[16];
 
-    // Becomes true when a Chip8 Hires program is detected.
-    bool mHires = false;
-
-    // Becomes true when Schip8 hires is enabled.
-    bool mSuperhires = false;
-
     // True while the program is executing.
     bool mRunning = false;
 

--- a/src/chip8/render.hpp
+++ b/src/chip8/render.hpp
@@ -1,32 +1,33 @@
 #pragma once
 #include <stdint.h>
 
+enum RenderMode { CHIP8, CHIP8HI, SCHIP8 };
+
 // These methods need to be implemented to provide the drawing, sound, and
 // random functionality that the Chip8 engine needs.
 //
 // Also includes a hook for any special exit behavior.
 class Render {
-    public:
-    // return the current state of the screen memory at the given coordinate,
-    // true if on, false if off.
-    virtual bool getPixel(uint8_t x, uint8_t y) = 0;
+    protected: 
+    RenderMode mMode;
 
-    // set the screen memory at location x, y to the provided state.
-    virtual void drawPixel(uint8_t x, uint8_t y, bool on) = 0;
+    public:
+    // if it should trigger a collision, return true.
+    virtual bool drawPixel(uint8_t x, uint8_t y, bool drawVal) = 0;
+
+    // set the resolution mode
+    virtual void setMode(RenderMode mode) { mMode = mode; }
+
+    // get the resolution mode
+    virtual RenderMode mode() { return mMode; }
 
     // draw the screen
     virtual void render() = 0;
 
     // clear the screen
     virtual void clear() = 0;
-
-    // implementations should make a noise for dur/60 seconds.
-    virtual void beep(uint8_t dur) = 0;
-
-    // implementations should return a uniform random number from 0 - 0xFF
-    virtual uint8_t random() = 0;
-
     
+
     // SUPER CHIP-8
     
     // scroll the display down the specified number of lines
@@ -40,4 +41,13 @@ class Render {
 
     // implement if you want to perform custom actions when emulator exits
     virtual void exit() = 0;
-};
+
+
+    // Non-drawing rendering
+    
+    // implementations should make a noise for dur/60 seconds.
+    virtual void beep(uint8_t dur) = 0;
+
+    // implementations should return a uniform random number from 0 - 0xFF
+    virtual uint8_t random() = 0;
+};    


### PR DESCRIPTION
A lot of Arduboy display-specific logic was still living in the chip8
engine itself. This commit moves that logic into the Arduboy renderer,
and simplifies the API a bit, as well.

Also add some more comments, and the missing scrollRight method.