### PR TITLE
Fix a bug in slab read when reading only from slabs

### DIFF
--- a/src/arduboy/mem.cpp
+++ b/src/arduboy/mem.cpp
@@ -12,6 +12,8 @@ void ArduMem::load(const uint8_t *program, const uint16_t size)  {
 }
 
 bool ArduMem::externalRead(uint16_t addr, uint8_t *dest, uint8_t size) {
+    if(size == 0) return true;
+
     uint8_t *src = NULL;
 
     if(addr + size < sizeof(font)) {

--- a/src/chip8/SlabMemory.cpp
+++ b/src/chip8/SlabMemory.cpp
@@ -96,10 +96,9 @@ bool SlabMemory::read(uint16_t addr, uint8_t* dest, uint8_t size) {
         }
     } while(size > 0 && slab);
 
-    
     // After the final slab is handled, this handles any remaining pgm data that
     // may need to be written.
-    return externalRead(addr, dest, size);
+    return size > 0 ? externalRead(addr, dest, size) : true;
 }
 
 // writeMem finds or allocates a slab of memory and


### PR DESCRIPTION
* No need to do externalRead at the end of a slab read, if remaining
  size is 0.
* Even so, if the arudboy read request is of size 0, return true even if
  it's for an address not represented.