### PR TITLE
Improve arduboy timing behavior

### DIFF
--- a/arduboy/arduboy.ino
+++ b/arduboy/arduboy.ino
@@ -26,11 +26,16 @@ uint8_t pidx;
 const Program *program;
 bool super = false;
 
-unsigned long next = 0;
+uint32_t next_tick = 0;
+uint16_t cycles_per_tick = 60;
+uint16_t cycles = 0;
 void runEmu() {
-    if(boy.nextFrame()) {
+    unsigned long now = micros();
+    if(now > next_tick) {
         render.tick();
         emu.Tick();
+        next_tick = now + 16666;
+        cycles = 0;
     }
 
     // If the emulator exited, we show a message that pressing a key will
@@ -51,11 +56,9 @@ void runEmu() {
         return;
     }
 
-    unsigned long t = micros();
-    if(t < next) {
+    if(cycles >= cycles_per_tick) {
         return;
     }
-    next = t + (super ? 100 : 1000);
     if(boy.pressed(UP_BUTTON) &&
             boy.pressed(DOWN_BUTTON) && 
             boy.pressed(LEFT_BUTTON) && 
@@ -65,6 +68,7 @@ void runEmu() {
         program = NULL;
     }
 
+    cycles++;
     ErrorType error = emu.Step();
     
     if(error != NO_ERROR) {

--- a/src/arduino/tracer.cpp
+++ b/src/arduino/tracer.cpp
@@ -6,6 +6,7 @@ inline void SerialTracer::command() {
         uint8_t com = Serial.read();
         switch(com) {
             case ' ': mExec = !mExec; break;
+            case 't': mTicks = !mTicks; break;
             case '0': mExecFinishedThreshold = 0; break;
             case '1': mExecFinishedThreshold = 1; break;
             case '2': mExecFinishedThreshold = 2; break;
@@ -15,6 +16,7 @@ inline void SerialTracer::command() {
 }
 
 void SerialTracer::exec(const EmuState &state, const Config &config) {
+    mCyclesThisTick++;
     command();
     if(mExec) {
         mPrint.printfs(
@@ -48,6 +50,19 @@ void SerialTracer::execFinished(const EmuState &state, const Config &config) {
         );
     }
 }
+
+void SerialTracer::tick(const EmuState &state, const Config &config) {
+    command();
+    if(mTicks) {
+        mPrint.printfs(
+            D16, mCyclesThisTick,
+            FS, F(" cycles/tick\r\n"),
+            DONE
+        );
+        mCyclesThisTick = 0;
+    }
+}
+
 
 __FlashStringHelper* SerialTracer::errorMessage(ErrorType errorType) {
     switch(errorType) {

--- a/src/arduino/tracer.hpp
+++ b/src/arduino/tracer.hpp
@@ -13,6 +13,8 @@ class SerialTracer : public Tracer {
     bool mExec = false;
     uint8_t mExecFinishedThreshold = 0;
     bool mError = true;
+    uint16_t mCyclesThisTick;
+    bool mTicks = false;
 
     void command();
 
@@ -24,5 +26,6 @@ class SerialTracer : public Tracer {
         virtual void exec(const EmuState &state, const Config &config);
         virtual void execFinished(const EmuState &state, const Config &config);
         virtual void error(ErrorType errorType, const EmuState &state, const Config &config); 
+        virtual void tick(const EmuState &state, const Config &config); 
 };
 

--- a/src/chip8/chip8.cpp
+++ b/src/chip8/chip8.cpp
@@ -22,6 +22,7 @@ void Chip8::Reset() {
 // namely, beep timer and delay timer, and triggers screen draw.
 void Chip8::Tick() {
     mRender.render();
+    mTracer.tick(mState, mConfig);
     if(mState.DelayTimer > 0) {
         mState.DelayTimer--;
     }

--- a/src/chip8/tracer.hpp
+++ b/src/chip8/tracer.hpp
@@ -13,4 +13,6 @@ class Tracer {
     virtual inline void execFinished(const EmuState &state, const Config &config) {} 
     // Called when execution of an instruction results in an error.
     virtual inline void error(ErrorType errorType, const EmuState &state, const Config &config) {}
+    // Called on each tick
+    virtual inline void tick(const EmuState &state, const Config &config) {}
 };


### PR DESCRIPTION
nextFrame will idle the CPU, which means we might not run a lot of
ticks, so switch to manually tracking time.

Control speed with a "cycle per tick" setting. Eventually we can make
this a config.